### PR TITLE
Create architecture to scrobble from multiple sources

### DIFF
--- a/src/api-wrappers/lastfm.test.ts
+++ b/src/api-wrappers/lastfm.test.ts
@@ -58,7 +58,10 @@ describe("LastFM", () => {
         user: mockEnv.LASTFM_USERNAME,
         limit: "1",
       });
-      expect(result).toEqual(mockTrack);
+      expect(result).toEqual({
+        name: "Test Track",
+        artist: "Test Artist",
+      });
     });
 
     it("should return undefined if no tracks are found", async () => {
@@ -124,7 +127,10 @@ describe("LastFM", () => {
 
       const result = await lastfm.getLatestSong();
 
-      expect(result).toEqual(mockTrack);
+      expect(result).toEqual({
+        name: "Test Track",
+        artist: "Test Artist",
+      });
     });
   });
 });

--- a/src/api-wrappers/lastfm.ts
+++ b/src/api-wrappers/lastfm.ts
@@ -1,6 +1,7 @@
 import { LastFm } from "@imikailoby/lastfm-ts";
 import { RecentTrack } from "./lastfm.types";
 import { Env } from "../types";
+import { NormalizedTrack } from "../types/track";
 
 export class LastFM {
   private client: LastFm;
@@ -11,7 +12,7 @@ export class LastFM {
     this.username = env.LASTFM_USERNAME;
   }
 
-  async getLatestSong(): Promise<RecentTrack | undefined> {
+  async getLatestSong(): Promise<NormalizedTrack | undefined> {
     try {
       const response = await this.client.user.getRecentTracks({
         user: this.username,
@@ -22,10 +23,23 @@ export class LastFM {
         return;
       }
 
-      return response.recenttracks.track[0];
+      return this.normalizeTrack(response.recenttracks.track[0]);
     } catch (error) {
       console.error("Failed to fetch latest song:", error);
       return;
     }
+  }
+
+  private normalizeTrack(
+    track: RecentTrack | undefined,
+  ): NormalizedTrack | undefined {
+    if (!track) {
+      return;
+    }
+
+    return {
+      name: track.name,
+      artist: track.artist["#text"],
+    };
   }
 }

--- a/src/services/latest-track-fetcher.ts
+++ b/src/services/latest-track-fetcher.ts
@@ -1,0 +1,42 @@
+import { LastFM } from "../api-wrappers/lastfm";
+import { RecentTrack } from "../api-wrappers/lastfm.types";
+import { Env } from "../types";
+import { NormalizedTrack } from "../types/track";
+
+type EnabledServices = "lastfm";
+
+export class LatestTrackFetcher {
+  private env: Env;
+  private lastfm: LastFM;
+
+  constructor(env: Env) {
+    this.env = env;
+    this.lastfm = new LastFM(env);
+  }
+
+  async fetchLatestTrack(): Promise<NormalizedTrack | undefined> {
+    const enabledServices = await this.getEnabledServices();
+
+    let latestTrackChecks: Promise<NormalizedTrack | undefined>[] = [];
+
+    if (enabledServices.includes("lastfm")) {
+      latestTrackChecks.push(this.lastfm.getLatestSong());
+    }
+
+    const latestTracks = await Promise.all(latestTrackChecks);
+
+    // TODO: As we add more services, we'll need to sort by timestamp across multiple services.
+    // For now, just the first one works for our current needs.
+    return latestTracks[0];
+  }
+
+  private async getEnabledServices() {
+    let enabledServices: EnabledServices[] = [];
+
+    if (this.env.LASTFM_API_KEY) {
+      enabledServices.push("lastfm");
+    }
+
+    return enabledServices;
+  }
+}

--- a/src/services/sync.test.ts
+++ b/src/services/sync.test.ts
@@ -15,9 +15,7 @@ describe("sync", () => {
   it("should update BlueSky profile with latest song", async () => {
     const mockTrack = {
       name: "Test Track",
-      artist: { "#text": "Test Artist", mbid: "" },
-      album: { "#text": "Test Album", mbid: "" },
-      url: "https://test.url",
+      artist: "Test Artist",
     };
 
     const mockUpdateDescription = vi.fn();
@@ -53,9 +51,7 @@ describe("sync", () => {
   it("should preserve existing description and replace Now Playing", async () => {
     const mockTrack = {
       name: "Test Track",
-      artist: { "#text": "Test Artist", mbid: "" },
-      album: { "#text": "Test Album", mbid: "" },
-      url: "https://test.url",
+      artist: "Test Artist",
     };
 
     const mockUpdateDescription = vi.fn();
@@ -81,9 +77,7 @@ describe("sync", () => {
   it("should handle BlueSky errors", async () => {
     const mockTrack = {
       name: "Test Track",
-      artist: { "#text": "Test Artist", mbid: "" },
-      album: { "#text": "Test Album", mbid: "" },
-      url: "https://test.url",
+      artist: "Test Artist",
     };
 
     vi.mocked(LastFM.prototype.getLatestSong).mockResolvedValue(mockTrack);

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -1,12 +1,12 @@
 import { Env } from "../types";
 import { BlueSky } from "../api-wrappers/bluesky";
-import { LastFM } from "../api-wrappers/lastfm";
+import { LatestTrackFetcher } from "./latest-track-fetcher";
 
 export const sync = async (env: Env) => {
-  const lastfm = new LastFM(env);
-  const latestSong = await lastfm.getLatestSong();
+  const latestTrackFetcher = new LatestTrackFetcher(env);
+  const latestTrack = await latestTrackFetcher.fetchLatestTrack();
 
-  if (latestSong) {
+  if (latestTrack) {
     try {
       const bluesky = await BlueSky.retrieveAgent(env);
       const profile = await bluesky.getProfile();
@@ -15,7 +15,7 @@ export const sync = async (env: Env) => {
         profile?.description || "",
       );
 
-      const newDescription = `${existingDescription}\n\n🎵 Now Playing: "${latestSong.name}" by ${latestSong.artist["#text"]}`;
+      const newDescription = `${existingDescription}\n\n🎵 Now Playing: "${latestTrack.name}" by ${latestTrack.artist}`;
 
       await bluesky.updateDescription(newDescription);
     } catch (error) {

--- a/src/types/track.ts
+++ b/src/types/track.ts
@@ -1,0 +1,4 @@
+export interface NormalizedTrack {
+  name: string;
+  artist: string;
+}


### PR DESCRIPTION
As we add more sources (as tracked in issues #1 and #2) we will need to a.) have a normalized track interface to represent a track from any scrobbling service b.) need to query across whatever services are setup and find the latest track. This change introduces the core structure for how we'll proceed down this path while keeping all existing behavior consistent. 