### PR TITLE
Make LastFM env variables optional

### DIFF
--- a/src/api-wrappers/lastfm.ts
+++ b/src/api-wrappers/lastfm.ts
@@ -8,6 +8,10 @@ export class LastFM {
   private username: string;
 
   constructor(env: Env) {
+    if (!env.LASTFM_API_KEY || !env.LASTFM_USERNAME) {
+      throw new Error("LASTFM_API_KEY and LASTFM_USERNAME must be set.");
+    }
+
     this.client = new LastFm(env.LASTFM_API_KEY);
     this.username = env.LASTFM_USERNAME;
   }

--- a/src/services/latest-track-fetcher.test.ts
+++ b/src/services/latest-track-fetcher.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { LatestTrackFetcher } from "./latest-track-fetcher";
+import { mockEnv } from "../../tests/fixtures/env";
+import { NormalizedTrack } from "../types/track";
+
+const mockGetLatestSong = vi.fn();
+
+vi.mock("../api-wrappers/lastfm", () => ({
+  LastFM: vi.fn().mockImplementation(() => ({
+    getLatestSong: mockGetLatestSong,
+  })),
+}));
+
+describe("LatestTrackFetcher", () => {
+  let fetcher: LatestTrackFetcher;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetcher = new LatestTrackFetcher(mockEnv);
+  });
+
+  describe("fetchLatestTrack", () => {
+    it("should fetch track from LastFM when enabled", async () => {
+      const mockTrack: NormalizedTrack = {
+        artist: "Test Artist",
+        name: "Test Song",
+      };
+
+      mockGetLatestSong.mockResolvedValueOnce(mockTrack);
+
+      const result = await fetcher.fetchLatestTrack();
+
+      expect(mockGetLatestSong).toHaveBeenCalled();
+      expect(result).toEqual(mockTrack);
+    });
+
+    it("should return undefined when no track is found", async () => {
+      mockGetLatestSong.mockResolvedValueOnce(undefined);
+
+      const result = await fetcher.fetchLatestTrack();
+
+      expect(mockGetLatestSong).toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw when no services are enabled", async () => {
+      const envWithoutLastFM = { ...mockEnv, LASTFM_API_KEY: undefined };
+
+      fetcher = new LatestTrackFetcher(envWithoutLastFM);
+
+      await expect(fetcher.fetchLatestTrack()).rejects.toThrow(
+        "You must enable at least one service to fetch the latest track.",
+      );
+
+      expect(mockGetLatestSong).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/latest-track-fetcher.ts
+++ b/src/services/latest-track-fetcher.ts
@@ -1,9 +1,14 @@
 import { LastFM } from "../api-wrappers/lastfm";
-import { RecentTrack } from "../api-wrappers/lastfm.types";
 import { Env } from "../types";
 import { NormalizedTrack } from "../types/track";
 
 type EnabledServices = "lastfm";
+
+class NoEnabledServicesError extends Error {
+  constructor() {
+    super("You must enable at least one service to fetch the latest track.");
+  }
+}
 
 export class LatestTrackFetcher {
   private env: Env;
@@ -16,6 +21,10 @@ export class LatestTrackFetcher {
 
   async fetchLatestTrack(): Promise<NormalizedTrack | undefined> {
     const enabledServices = await this.getEnabledServices();
+
+    if (enabledServices.length === 0) {
+      throw new NoEnabledServicesError();
+    }
 
     let latestTrackChecks: Promise<NormalizedTrack | undefined>[] = [];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,6 @@ export interface Env {
   BSKY_USERNAME: string;
   BSKY_PASSWORD: string;
   BSKY_SERVICE?: string;
-  LASTFM_API_KEY: string;
-  LASTFM_USERNAME: string;
+  LASTFM_API_KEY?: string;
+  LASTFM_USERNAME?: string;
 }


### PR DESCRIPTION
Since we're moving to a world where Last.FM is an optional part of worker we need to make some modifications to handle gracefully when it's not set. 