### PR TITLE
Add better logging when rate limited for Bluesky

### DIFF
--- a/src/errors/rate-limit-error.ts
+++ b/src/errors/rate-limit-error.ts
@@ -1,0 +1,6 @@
+export class RateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}

--- a/src/types/bluesky.ts
+++ b/src/types/bluesky.ts
@@ -1,0 +1,10 @@
+export interface BlueskyRateLimitExceededError {
+  name: "RateLimitExceeded";
+  headers: {
+    "ratelimit-limit": string;
+    "ratelimit-policy": string;
+    "ratelimit-remaining": string;
+    "ratelimit-reset": string;
+  };
+  statusText: string;
+}


### PR DESCRIPTION
I pretty quickly hit a rate limit with the Bluesky API and didn't have a lot of visibility into when it ended. This error could be enhanced in the future with more details, but all I needed today was to know when the rate limit was going to end.

This is a potential step in handling rate limits better and backing off until the limit ends.