### PR TITLE
Separate profile generation to own class

### DIFF
--- a/src/services/profile-description-generator.test.ts
+++ b/src/services/profile-description-generator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { ProfileDescriptionGenerator } from "./profile-description-generator";
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { NormalizedTrack } from "../types/track";
+
+describe("ProfileDescriptionGenerator", () => {
+  const mockTrack: NormalizedTrack = {
+    artist: "Test Artist",
+    name: "Test Song",
+  };
+
+  it("should generate description with only now playing when no existing description", () => {
+    const generator = new ProfileDescriptionGenerator(undefined, mockTrack);
+
+    expect(generator.call()).toBe('🎵 Now Playing: "Test Song" by Test Artist');
+  });
+
+  it("should append now playing to existing description", () => {
+    const profile: ProfileViewDetailed = {
+      did: "test-did",
+      handle: "test.handle",
+      description: "My cool profile",
+    } as ProfileViewDetailed;
+
+    const generator = new ProfileDescriptionGenerator(profile, mockTrack);
+
+    expect(generator.call()).toBe(
+      'My cool profile\n\n🎵 Now Playing: "Test Song" by Test Artist',
+    );
+  });
+
+  it("should update existing now playing section", () => {
+    const profile: ProfileViewDetailed = {
+      did: "test-did",
+      handle: "test.handle",
+      description:
+        'My cool profile\n\n🎵 Now Playing: "Old Song" by Old Artist',
+    } as ProfileViewDetailed;
+
+    const generator = new ProfileDescriptionGenerator(profile, mockTrack);
+
+    expect(generator.call()).toBe(
+      'My cool profile\n\n🎵 Now Playing: "Test Song" by Test Artist',
+    );
+  });
+
+  it("should handle empty description", () => {
+    const profile: ProfileViewDetailed = {
+      did: "test-did",
+      handle: "test.handle",
+      description: "",
+    } as ProfileViewDetailed;
+
+    const generator = new ProfileDescriptionGenerator(profile, mockTrack);
+
+    expect(generator.call()).toBe('🎵 Now Playing: "Test Song" by Test Artist');
+  });
+
+  it("should handle description with opening newlines and now playing", () => {
+    const profile: ProfileViewDetailed = {
+      did: "test-did",
+      handle: "test.handle",
+      description: "\n\n🎵 Now Playing: 'Old Song' by Old Artist",
+    } as ProfileViewDetailed;
+
+    const generator = new ProfileDescriptionGenerator(profile, mockTrack);
+
+    expect(generator.call()).toBe('🎵 Now Playing: "Test Song" by Test Artist');
+  });
+
+  it("should handle description with only now playing", () => {
+    const profile: ProfileViewDetailed = {
+      did: "test-did",
+      handle: "test.handle",
+      description: '🎵 Now Playing: "Old Song" by Old Artist',
+    } as ProfileViewDetailed;
+
+    const generator = new ProfileDescriptionGenerator(profile, mockTrack);
+
+    expect(generator.call()).toBe('🎵 Now Playing: "Test Song" by Test Artist');
+  });
+});

--- a/src/services/profile-description-generator.ts
+++ b/src/services/profile-description-generator.ts
@@ -1,0 +1,36 @@
+import { ProfileViewDetailed } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import { NormalizedTrack } from "../types/track";
+
+export class ProfileDescriptionGenerator {
+  constructor(
+    private profile: ProfileViewDetailed | undefined,
+    private latestTrack: NormalizedTrack,
+  ) {
+    this.profile = profile;
+    this.latestTrack = latestTrack;
+  }
+
+  call(): string {
+    if (this.getBaseDescription().length === 0) {
+      return this.getNowPlayingDescription();
+    }
+
+    return `${this.getBaseDescription()}\n\n${this.getNowPlayingDescription()}`;
+  }
+
+  private getBaseDescription(): string {
+    let baseDescription = this.profile?.description ?? "";
+
+    const nowPlayingIndex = baseDescription?.indexOf("🎵 Now Playing:");
+
+    if (nowPlayingIndex === -1) {
+      return baseDescription.trim();
+    }
+
+    return baseDescription?.substring(0, nowPlayingIndex).trim();
+  }
+
+  private getNowPlayingDescription(): string {
+    return `🎵 Now Playing: "${this.latestTrack.name}" by ${this.latestTrack.artist}`;
+  }
+}


### PR DESCRIPTION
I noticed that when a profile was previously empty we would be appending two newlines before it which created a weird visual. I also wanted to split out the profile generation into its own class as this will be getting more complicated as things progress.