### PR TITLE
Guard number of writes to KV

### DIFF
--- a/src/api-wrappers/bluesky.ts
+++ b/src/api-wrappers/bluesky.ts
@@ -31,10 +31,19 @@ export class BlueSky {
         _: AtpSessionEvent,
         sessionData?: AtpSessionData,
       ) => {
-        await env.BLUESKY_SESSION_STORAGE.put(
-          SESSION_KEY,
-          JSON.stringify(sessionData),
-        );
+        const stringifiedSessionData = JSON.stringify(sessionData);
+
+        const existingSessionData =
+          await env.BLUESKY_SESSION_STORAGE.get(SESSION_KEY);
+
+        // Protect the number of writes we make to KV to avoid hitting the limits
+        // of Cloudflare's free tier.
+        if (existingSessionData !== stringifiedSessionData) {
+          await env.BLUESKY_SESSION_STORAGE.put(
+            SESSION_KEY,
+            JSON.stringify(sessionData),
+          );
+        }
       },
     });
   }


### PR DESCRIPTION
Resolves #14 

Essentially, each time we did a `resumeSession` it calls `persistSession` again and we were naively re-writing the session to our storage. Now we check if it's changed before writing which was the main bottleneck on using this on a a free tier. 