### PR TITLE
Update the weekly top artists cron expression in `wrangler.toml.example`

### DIFF
--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -9,7 +9,7 @@ kv_namespaces = [
 [triggers]
 crons = [
   "* * * * *",      # Every minute for track sync
-  "0 10 * * 1"      # Every Monday at 10am EST for weekly top artists
+  "0 15 * * 6"      # Every Friday at 15:00 UTC for weekly top artists
 ]
 
 [observability.logs]


### PR DESCRIPTION
This PR updates the weekly artists cron expression in the `wrangler.toml.example` to match the expected value.

While I was setting up I was a little confused about the cron expression, as it didn't seem to line up with what I expected.

I then saw that in https://github.com/willmanduffy/scrobble-blue/pull/18 you had fixed the cron expression.
